### PR TITLE
fix on_failure callback from always firing

### DIFF
--- a/addons/HTTPManager/classes/HTTPManagerJob.gd
+++ b/addons/HTTPManager/classes/HTTPManagerJob.gd
@@ -194,7 +194,7 @@ func on_success_set( object:Object, property:String ) -> HTTPManagerJob:
 ##add a callback that will be called when request fails in any way
 func on_failure( callback:Callable ) -> HTTPManagerJob:
 	callbacks.append({
-		"successful": false,
+		"success": false,
 		"callback": callback
 	})
 	


### PR DESCRIPTION
property "successful" should have been "success", otherwise the on_failure callback will always fire